### PR TITLE
Resolve conflicts on benchmarks from hcai-bench suite

### DIFF
--- a/hcai-bench/svcomp/O0/O0_sum04_false-unreach-call_true-termination_000.yml
+++ b/hcai-bench/svcomp/O0/O0_sum04_false-unreach-call_true-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O0_sum04_false-unreach-call_true-termination_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false 
   property_file: ../../../properties/check-sat.prp

--- a/hcai-bench/svcomp/O3/O3_BallRajamani-SPIN2000-Fig1_false-unreach-call_true-no-overflow_true-termination_000.yml
+++ b/hcai-bench/svcomp/O3/O3_BallRajamani-SPIN2000-Fig1_false-unreach-call_true-no-overflow_true-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O3_BallRajamani-SPIN2000-Fig1_false-unreach-call_true-no-overflow_t
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/hcai-bench/svcomp/O3/O3_afterrec_false-unreach-call_true-termination_000.yml
+++ b/hcai-bench/svcomp/O3/O3_afterrec_false-unreach-call_true-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O3_afterrec_false-unreach-call_true-termination_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp


### PR DESCRIPTION
The following benchmarks have been determined as SAT by CHC2C, but as UNSAT by all other solvers (when they were able to solve them):

```
hcai-bench/svcomp/O0/O0_sum04_false-unreach-call_true-termination_000.smt2
hcai-bench/svcomp/O3/O3_BallRajamani-SPIN2000-Fig1_false-unreach-call_true-no-overflow_true-termination_000.smt2
hcai-bench/svcomp/O3/O3_afterrec_false-unreach-call_true-termination_000.smt2
```
Moreover, Golem is able to produce proof of unsatisfiability for each of these benchmarks and the proofs have been validated by the Carcara proof checker.