### PR TITLE
Resolve additional conflicts in LIA-Lin benchmarks

### DIFF
--- a/eldarica-misc/LIA/llreve/digits10_inl_safe.c-1_000.yml
+++ b/eldarica-misc/LIA/llreve/digits10_inl_safe.c-1_000.yml
@@ -3,5 +3,5 @@ input_files: digits10_inl_safe.c-1_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false 
   property_file: ../../../properties/check-sat.prp

--- a/eldarica-misc/LIA/reve/003c-horn_000.yml
+++ b/eldarica-misc/LIA/reve/003c-horn_000.yml
@@ -3,5 +3,5 @@ input_files: 003c-horn_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/eldarica-misc/LIA/reve/003d-horn_000.yml
+++ b/eldarica-misc/LIA/reve/003d-horn_000.yml
@@ -3,5 +3,5 @@ input_files: 003d-horn_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/eldarica-misc/LIA/reve/020c-horn_000.yml
+++ b/eldarica-misc/LIA/reve/020c-horn_000.yml
@@ -3,5 +3,5 @@ input_files: 020c-horn_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/hcai-bench/svcomp/O0/O0_nec11_false-unreach-call_false-termination_000.yml
+++ b/hcai-bench/svcomp/O0/O0_nec11_false-unreach-call_false-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O0_nec11_false-unreach-call_false-termination_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/hcai-bench/svcomp/O3/O3_afterrec_2calls_false-unreach-call_true-termination_000.yml
+++ b/hcai-bench/svcomp/O3/O3_afterrec_2calls_false-unreach-call_true-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O3_afterrec_2calls_false-unreach-call_true-termination_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/llreve-bench/smt2/faulty__barthe!_000.yml
+++ b/llreve-bench/smt2/faulty__barthe!_000.yml
@@ -3,5 +3,5 @@ input_files: faulty__barthe!_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/llreve-bench/smt2/faulty__loop5!_000.yml
+++ b/llreve-bench/smt2/faulty__loop5!_000.yml
@@ -3,5 +3,5 @@ input_files: faulty__loop5!_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/llreve-bench/smt2/faulty__nested-while!_000.yml
+++ b/llreve-bench/smt2/faulty__nested-while!_000.yml
@@ -3,5 +3,5 @@ input_files: faulty__nested-while!_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp


### PR DESCRIPTION
The following benchmarks were reported as SAT by ThetaCHC, but UNSAT by several other solvers. Moreover, Golem is able to produce proofs of unsatisfiability that have been validated by Carcara.

```
eldarica-misc/LIA/llreve/digits10_inl_safe.c-1_000.smt2 eldarica-misc/LIA/reve/003c-horn_000.smt2
eldarica-misc/LIA/reve/003d-horn_000.smt2
eldarica-misc/LIA/reve/020c-horn_000.smt2
hcai-bench/svcomp/O0/O0_nec11_false-unreach-call_false-termination_000.smt2 hcai-bench/svcomp/O3/O3_afterrec_2calls_false-unreach-call_true-termination_000.smt2 llreve-bench/smt2/faulty__barthe!_000.smt2
llreve-bench/smt2/faulty__loop5!_000.smt2
llreve-bench/smt2/faulty__nested-while!_000.smt2
```