### PR TITLE
Resolve conflicts in LRA-Lin benchmarks

### DIFF
--- a/sally-chc-benchmarks/approximate_agreement/approx_hybrid.6.c_000.yml
+++ b/sally-chc-benchmarks/approximate_agreement/approx_hybrid.6.c_000.yml
@@ -3,5 +3,5 @@ input_files: approx_hybrid.6.c_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_non_convergence_000.yml
+++ b/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_non_convergence_000.yml
@@ -3,5 +3,5 @@ input_files: scenario2_non_convergence_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_revised_non_convergence_000.yml
+++ b/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_revised_non_convergence_000.yml
@@ -3,5 +3,5 @@ input_files: scenario2_revised_non_convergence_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_strict_000.yml
+++ b/sally-chc-benchmarks/azadmanesh-kieckhafer/scenario2_strict_000.yml
@@ -3,5 +3,5 @@ input_files: scenario2_strict_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/misc/mvs_with_timeouts3_000.yml
+++ b/sally-chc-benchmarks/misc/mvs_with_timeouts3_000.yml
@@ -3,5 +3,5 @@ input_files: mvs_with_timeouts3_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/tte_synchro/tte_synchro.cm_clock_distance_strict_000.yml
+++ b/sally-chc-benchmarks/tte_synchro/tte_synchro.cm_clock_distance_strict_000.yml
@@ -3,5 +3,5 @@ input_files: tte_synchro.cm_clock_distance_strict_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/tte_synchro/tte_synchro.sm_clock_distance_strict_000.yml
+++ b/sally-chc-benchmarks/tte_synchro/tte_synchro.sm_clock_distance_strict_000.yml
@@ -3,5 +3,5 @@ input_files: tte_synchro.sm_clock_distance_strict_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/sally-chc-benchmarks/unified-approx/scenario3_convergence_000.yml
+++ b/sally-chc-benchmarks/unified-approx/scenario3_convergence_000.yml
@@ -3,5 +3,5 @@ input_files: scenario3_convergence_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp


### PR DESCRIPTION
The following benchmarks were reported as SAT by Eldarica, but UNSAT as Golem and ThetaCHC. Moreover, Z3/Spacer also says that they are UNSAT and Golem can internally validate the UNSAT proofs.

```
approximate_agreement/approx_hybrid.6.c_000.smt2
azadmanesh-kieckhafer/scenario2_non_convergence_000.smt2
azadmanesh-kieckhafer/scenario2_revised_non_convergence_000.smt2
azadmanesh-kieckhafer/scenario2_strict_000.smt2
misc/mvs_with_timeouts3_000.smt2
tte_synchro/tte_synchro.cm_clock_distance_strict_000.smt2
tte_synchro/tte_synchro.sm_clock_distance_strict_000.smt2
unified-approx/scenario3_convergence_000.smt2
```