### PR TITLE
Resolve conflicts on LIA benchmarks

### DIFF
--- a/hcai-bench/svcomp/O0/O0_afterrec_false-unreach-call_true-termination_000.yml
+++ b/hcai-bench/svcomp/O0/O0_afterrec_false-unreach-call_true-termination_000.yml
@@ -3,5 +3,5 @@ input_files: O0_afterrec_false-unreach-call_true-termination_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_1_e7_2044_000.yml
+++ b/kind2-chc-benchmarks/data/fast_1_e7_2044_000.yml
@@ -3,5 +3,5 @@ input_files: fast_1_e7_2044_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_1_e7_2044_e7_1287_000.yml
+++ b/kind2-chc-benchmarks/data/fast_1_e7_2044_e7_1287_000.yml
@@ -3,5 +3,5 @@ input_files: fast_1_e7_2044_e7_1287_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_1_e8_747_e7_692_000.yml
+++ b/kind2-chc-benchmarks/data/fast_1_e8_747_e7_692_000.yml
@@ -3,5 +3,5 @@ input_files: fast_1_e8_747_e7_692_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_2_e7_2526_000.yml
+++ b/kind2-chc-benchmarks/data/fast_2_e7_2526_000.yml
@@ -3,5 +3,5 @@ input_files: fast_2_e7_2526_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false 
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_2_e7_2526_e7_2736_000.yml
+++ b/kind2-chc-benchmarks/data/fast_2_e7_2526_e7_2736_000.yml
@@ -3,5 +3,5 @@ input_files: fast_2_e7_2526_e7_2736_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/fast_2_e8_460_e7_43_000.yml
+++ b/kind2-chc-benchmarks/data/fast_2_e8_460_e7_43_000.yml
@@ -3,5 +3,5 @@ input_files: fast_2_e8_460_e7_43_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/kind2-chc-benchmarks/data/two_counters_e2_3_000.yml
+++ b/kind2-chc-benchmarks/data/two_counters_e2_3_000.yml
@@ -3,5 +3,5 @@ input_files: two_counters_e2_3_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/synthesis/nay-horn/PLUS_array_sum_6_5_000.yml
+++ b/synthesis/nay-horn/PLUS_array_sum_6_5_000.yml
@@ -3,5 +3,5 @@ input_files: PLUS_array_sum_6_5_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/synthesis/nay-horn/PLUS_mpg_example1_000.yml
+++ b/synthesis/nay-horn/PLUS_mpg_example1_000.yml
@@ -3,5 +3,5 @@ input_files: PLUS_mpg_example1_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/synthesis/nay-horn/PLUS_mpg_example2_000.yml
+++ b/synthesis/nay-horn/PLUS_mpg_example2_000.yml
@@ -3,5 +3,5 @@ input_files: PLUS_mpg_example2_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/synthesis/nay-horn/PLUS_mpg_guard2_000.yml
+++ b/synthesis/nay-horn/PLUS_mpg_guard2_000.yml
@@ -3,5 +3,5 @@ input_files: PLUS_mpg_guard2_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp

--- a/synthesis/nay-horn/PLUS_mpg_plane3_000.yml
+++ b/synthesis/nay-horn/PLUS_mpg_plane3_000.yml
@@ -3,5 +3,5 @@ input_files: PLUS_mpg_plane3_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: false
   property_file: ../../properties/check-sat.prp


### PR DESCRIPTION
For the following benchmarks CHC2C reported SAT, but other solvers reported UNSAT. UNSAT results have been confirmed by checking UNSAT proofs from Golem with Carcara. Z3-Spacer also reports UNSAT.

