### PR TITLE
Resolve conflict on LIA benchmark

### DIFF
--- a/eldarica-misc/LIA/Consistency/point-location.48_000.yml
+++ b/eldarica-misc/LIA/Consistency/point-location.48_000.yml
@@ -3,5 +3,5 @@ input_files: point-location.48_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: true
   property_file: ../../../properties/check-sat.prp


### PR DESCRIPTION
For the following benchmark, Ultimate Unihorn returned UNSAT, but both Golem and Eldarica returned SAT. Z3-Spacer also returns SAT. Golem validated the model internally.

It would be good to get confirmation from external model validation as well, but I think the evidence is quite convincing already.