### PR TITLE
Resolve two conflicts in LIA-Lin-Arrays category

### DIFF
--- a/hcai-bench/svcomp/O0/O0_vogal_true-unreach-call_000.yml
+++ b/hcai-bench/svcomp/O0/O0_vogal_true-unreach-call_000.yml
@@ -3,5 +3,5 @@ input_files: O0_vogal_true-unreach-call_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: true
   property_file: ../../../properties/check-sat.prp

--- a/hcai-bench/svcomp/O3/O3_vogal_true-unreach-call_000.yml
+++ b/hcai-bench/svcomp/O3/O3_vogal_true-unreach-call_000.yml
@@ -3,5 +3,5 @@ input_files: O3_vogal_true-unreach-call_000.smt2
 options:
   language: SMT-LIB
 properties:
-- expected_verdict: inconsistent
+- expected_verdict: true
   property_file: ../../../properties/check-sat.prp


### PR DESCRIPTION
For the following two benchmarks Golem reported UNSAT, but other solvers reported SAT.

```
hcai-bench/svcomp/O0/O0_vogal_true-unreach-call_000.smt2
hcai-bench/svcomp/O3/O3_vogal_true-unreach-call_000.smt2
```

I tracked the issue to incorrect handling of arrays in preprocessor in Golem, After the fix, it no longer reports UNSAT for these benchmarks.